### PR TITLE
Import React correctly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import React from "react";
+const { useEffect, useMemo, useState } = React;
 
 export type Config = {
   readonly [key: string]: number;


### PR DESCRIPTION
React is a CommonJS-only module, so import { foo, bar } from 'react' is invalid. Specifically, it causes problems when doing SSR via webpack. See [nodejs documentation](https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_import_statements) for details on why this import is invalid.

The original problem I have is here: gatsbyjs/gatsby#22599 (comment) for details.