### PR TITLE
fix: only match default breakpoint, if none of the queries match

### DIFF
--- a/src/createMediaQueries.ts
+++ b/src/createMediaQueries.ts
@@ -11,14 +11,16 @@ export interface MediaQuery<C extends Config> {
  * Create media query objects
  * @param breakpoints the list of configured breakpoint names and their pixel values
  */
-const createMediaQueries = (breakpoints: Config): MediaQuery<Config>[] => {
+const createMediaQueries = <C extends Config>(
+  breakpoints: C,
+): MediaQuery<C>[] => {
   const sortedBreakpoints = Object.keys(breakpoints).sort(
     (a, b) => breakpoints[b] - breakpoints[a],
   )
 
   return sortedBreakpoints.map((breakpoint, index) => {
     let query = ''
-    const minWidth = breakpoints[breakpoint]
+    const minWidth = breakpoints[breakpoint] as C[keyof C]
     const nextBreakpoint = sortedBreakpoints[index - 1] as string | undefined
     const maxWidth = nextBreakpoint ? breakpoints[nextBreakpoint] : null
 
@@ -33,7 +35,7 @@ const createMediaQueries = (breakpoints: Config): MediaQuery<Config>[] => {
       query += `(max-width: ${maxWidth - 1}px)`
     }
 
-    const mediaQuery: MediaQuery<Config> = {
+    const mediaQuery = {
       breakpoint,
       maxWidth: maxWidth ? maxWidth - 1 : null,
       minWidth,

--- a/src/useBreakpoint.ts
+++ b/src/useBreakpoint.ts
@@ -84,30 +84,27 @@ const useBreakpoint = <C extends Config, D extends keyof C | undefined>(
   )
 
   const getSnapshot = useCallback(() => {
-    const match = mediaQueries.find((mediaQuery) => {
-      /**
-       * If we're in the browser and there's no default value,
-       * try to match actual breakpoint.
-       */
-      if (window.matchMedia(mediaQuery.query).matches) {
-        return true
-      }
+    const mediaMatch = mediaQueries.find(
+      (mediaQuery) => window.matchMedia(mediaQuery.query).matches,
+    )
+    if (mediaMatch) return mediaMatch
 
-      /** Otherwise, try to match default value */
-      if (mediaQuery.breakpoint === defaultBreakpoint) {
-        return true
-      }
-    }) as Breakpoint<C> | undefined
+    if (defaultBreakpoint) {
+      const defaultMatch = mediaQueries.find(
+        (mediaQuery) => mediaQuery.breakpoint === defaultBreakpoint,
+      )
+      if (defaultMatch) return defaultMatch
+    }
 
-    return match ?? EMPTY_BREAKPOINT
+    return EMPTY_BREAKPOINT
   }, [defaultBreakpoint, mediaQueries])
 
   const getServerSnapshot = useCallback(() => {
-    const match = mediaQueries.find(
-      (mediaQuery) => defaultBreakpoint === mediaQuery.breakpoint,
-    ) as Breakpoint<C> | undefined
+    const defaultMatch = mediaQueries.find(
+      (mediaQuery) => mediaQuery.breakpoint === defaultBreakpoint,
+    )
 
-    return match ?? EMPTY_BREAKPOINT
+    return defaultMatch ?? EMPTY_BREAKPOINT
   }, [defaultBreakpoint, mediaQueries])
 
   const currentBreakpoint = useSyncExternalStore(

--- a/story.tsx
+++ b/story.tsx
@@ -33,7 +33,7 @@ export const WithoutDefaultValue = (): React.JSX.Element => {
 }
 
 export const WithDefaultValue = (): React.JSX.Element => {
-  const { breakpoint, minWidth, maxWidth } = useBreakpoint(config, 'mobile')
+  const { breakpoint, minWidth, maxWidth } = useBreakpoint(config, 'desktop')
 
   React.useEffect(() => {
     console.log('breakpoint', breakpoint)

--- a/tests/useBreakpoint.jsdom.spec.ts
+++ b/tests/useBreakpoint.jsdom.spec.ts
@@ -37,6 +37,19 @@ describe('useBreakpoint', () => {
     expect(useDebugValueSpy.mock.calls[0][1]?.(EXPECTED)).toStrictEqual('')
   })
 
+  it('should return correct breakpoint client-side, with default value', () => {
+    matchMedia.useMediaQuery('(min-width: 0px) and (max-width: 767px)')
+
+    const { result } = renderHook(() => useBreakpoint(CONFIG, 'desktop'))
+
+    expect(result.current).toStrictEqual({
+      breakpoint: 'mobile',
+      minWidth: 0,
+      maxWidth: 767,
+      query: '(min-width: 0px) and (max-width: 767px)',
+    })
+  })
+
   it('should return default value client-side when set', () => {
     matchMedia.useMediaQuery('(min-width: 0px)')
 


### PR DESCRIPTION
In the previous implementation, the default breakpoint was always returned if it was the largest breakpoint, because of an incorrect Array.find() logic. The fix is to only find the default breakpoint, if none of the media queries match.